### PR TITLE
Updated FAQ Link

### DIFF
--- a/src/assets/download_history.html
+++ b/src/assets/download_history.html
@@ -76,7 +76,7 @@
                     </a>
                 </li>
                 <li>
-                        <a href="http://worldbrain.io/faq">
+                        <a href="http://worldbrain.io/faq" target="_blank">
                         <i class="pe-7s-help1"></i>
                         <p>Frequently asked Questions</p>
                     </a>


### PR DESCRIPTION
Here's the first of a number of pull requests with the aim of making the FAQ link open in a new tab.  This way when you're in teh extension settings the FAQ doesn't take you away from what you're looking at in the settings.

(apologies for not knowing how to bundle them all together).

