### PR TITLE
Issue 106 fix: characters are now recognized on imported websites

### DIFF
--- a/src/js-browserify/html.js
+++ b/src/js-browserify/html.js
@@ -32,7 +32,6 @@ function extractFromText( data, callback ) {
       .replace( WHITELIST_STRIP_LINEBREAKS, ' ' )
       .replace( / (?! )/g, '' )
       .replace( /[ \t\v\u00A0]{2,}/g, ' ' )
-      .replace(/[^a-zA-Z0-9]+/g, " ")
       ;
 
       

--- a/src/js-browserify/html.js
+++ b/src/js-browserify/html.js
@@ -18,7 +18,7 @@ function extractFromText( data, callback ) {
 
   text = '<textractwrapper>' + text + '<textractwrapper>';
 
-    $ = cheerio.load( text );
+    $ = cheerio.load( text , { decodeEntities: false } );
     $( 'script' ).remove();
     $( 'style' ).remove();
     $( 'noscript' ).remove();


### PR DESCRIPTION
Cheerio was encoding it in utf8 html earlier, for example - 首页 was getting converted to `&#x9996;&#x9875;` which was causing the problem.
Cheerio load has a field decodeEntities which is now set to false to prevent this. 